### PR TITLE
Fix role swapping timing - now occurs after round 4 (Bug #6)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,7 @@ const EMPEROR = "E";
 const CITIZEN = "C";
 const SLAVE = "S";
 const MAX_ROUNDS = 12;
-const SWAP_ROUND = 4; // Swaps after round 3 (on round 4)
+const SWAP_ROUND = 4; // Swaps after round 4 (starting from round 5)
 
 // --- Helper Functions ---
 const getInitialHand = (role) => {
@@ -224,7 +224,9 @@ function App() {
             let newEmperorRole = players[emperorPlayerId].role;
             let newSlaveRole = players[slavePlayerId].role;
             
-            if (round === SWAP_ROUND - 1) {
+            // Role swap logic: swap roles after completing round 4
+            // This means roles swap when round === 4 (after round 4 finishes, starting round 5)
+            if (round === SWAP_ROUND) {
                 newEmperorRole = 'slave';
                 newSlaveRole = 'emperor';
             }


### PR DESCRIPTION
Fixes critical role swapping timing bug in game logic.

## 🐛 Bug Fix

### Problem
- **Incorrect Timing**: Roles were swapping after round 3 instead of round 4
- **Game Logic Error**: Condition was  (round 3)
- **Impact**: Affected game balance and player expectations

### Root Cause


### Solution
- ✅ **Fixed condition**: Changed to 
- ✅ **Correct timing**: Roles now swap after round 4 completes
- ✅ **Clear documentation**: Added comments explaining the timing logic

### Game Flow (Fixed)
- **Rounds 1-4**: Original roles (Emperor vs Slave)  
- **Round 4 completes** → 🔄 **Role swap occurs**
- **Rounds 5-12**: Swapped roles (former Slave becomes Emperor, etc.)

### Testing
- ✅ Application compiles and runs successfully
- ✅ Logic change is isolated and focused
- ✅ No breaking changes to other game mechanics
- ✅ Maintains all existing functionality

### Impact
- **Game Balance**: Now follows correct Kaiji E-Card rules
- **User Experience**: Predictable role swapping behavior
- **Code Quality**: Clear, well-documented timing logic

Fixes critical bug #6 from codebase analysis.